### PR TITLE
Fixing parse error "unknown encoding: cpNONE"

### DIFF
--- a/ofxparse/ofxparse.py
+++ b/ofxparse/ofxparse.py
@@ -124,6 +124,8 @@ class OfxFile(object):
             cp = ascii_headers.get("CHARSET", "1252")
             if cp == "8859-1":
                 encoding = "iso-8859-1"
+            elif cp == "NONE":
+                encoding = "1252"
             else:
                 encoding = "cp%s" % (cp, )
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -123,6 +123,24 @@ NEWFILEUID:NONE
         ofx_file = self.OfxFileCls(fh)
         self.assertEqual(len(ofx_file.headers.keys()), 2)
 
+    def testUSASCIICharsetNone(self):
+        fh = six.BytesIO(six.b("""OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:USASCII
+CHARSET:NONE
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+"""))
+        ofx_file = self.OfxFileCls(fh)
+        headers = ofx_file.headers
+        result = ofx_file.fh.read()
+
+        self.assertTrue(type(result) is six.text_type)
+        self.assertHeadersTypes(headers)
+
 
 class TestOfxPreprocessedFile(TestOfxFile):
     OfxFileCls = OfxPreprocessedFile


### PR DESCRIPTION
This handles the case where the encoding is "USASCII" and the charset is
the string "NONE" instead of a valid charset. I've seen this in files
from two different institutions.